### PR TITLE
Restore support for the Kratos Narrowband Digitizer

### DIFF
--- a/lib/difi_sink_cpp_impl.cc
+++ b/lib/difi_sink_cpp_impl.cc
@@ -84,7 +84,7 @@ namespace gr {
       u_int64_t d_class_id;
       if(context_pack_size == 72)// this check is a temporary work around for a non-compliant hardware device
       {
-        d_class_id = 0x7c386c << 32; // This is the OUI that is required for the non-compliant hardware device
+        d_class_id = d_alt_oui << 32; // This is the OUI that is required for the non-compliant hardware device
       } else {
         d_class_id = d_oui << 32;
       }

--- a/lib/difi_sink_cpp_impl.cc
+++ b/lib/difi_sink_cpp_impl.cc
@@ -68,14 +68,26 @@ namespace gr {
       d_full = reference_time_full;
       d_frac = reference_time_frac;
       d_static_bits = 0x18e00000; // header bits 31-20 must be 0x18e (posix), 0x18a (gps), or 0x186 (utc)
-      d_context_static_bits = 0x49e00000;// header bits 31-20 must be 0x49e (posix), 0x49a (gps), or 0x496 (utc)
+      if(context_pack_size == 72)// this check is a temporary work around for a non-compliant hardware device
+      {
+        d_context_static_bits = 0x49000000;// header bits 31-20 must be 0x49e (posix), 0x49a (gps), or 0x496 (utc)
+      }
+      else {
+        d_context_static_bits = 0x49e00000;// header bits 31-20 must be 0x49e (posix), 0x49a (gps), or 0x496 (utc)
+      }
       d_unpack_idx_size = bit_depth == 8 ? 1 : 2;
       d_samples_per_packet = samples_per_packet;
       d_time_adj = (double)d_samples_per_packet / samp_rate;
       d_data_len = samples_per_packet * d_unpack_idx_size * 2;
       u_int32_t tmp_header_data = d_static_bits ^ d_pkt_n << 16 ^ (d_data_len + difi::DIFI_HEADER_SIZE) / 4;
       u_int32_t tmp_header_context = d_context_static_bits ^ d_context_packet_count << 16 ^ (context_pack_size  / 4);
-      u_int64_t d_class_id = d_oui << 32;
+      u_int64_t d_class_id;
+      if(context_pack_size == 72)// this check is a temporary work around for a non-compliant hardware device
+      {
+        d_class_id = 0x007c386c << 32; // This is the OUI that is required for the non-compliant hardware device
+      else {
+        d_class_id = d_oui << 32;
+      }
       u_int64_t d_context_class_id = d_class_id ^ 1;
       d_raw.resize(difi::DIFI_HEADER_SIZE);
       pack_u32(&d_raw[0], tmp_header_data);

--- a/lib/difi_sink_cpp_impl.cc
+++ b/lib/difi_sink_cpp_impl.cc
@@ -84,8 +84,8 @@ namespace gr {
       u_int64_t d_class_id;
       if(context_pack_size == 72)// this check is a temporary work around for a non-compliant hardware device
       {
-        d_class_id = 0x007c386c << 32; // This is the OUI that is required for the non-compliant hardware device
-      else {
+        d_class_id = 0x7c386c << 32; // This is the OUI that is required for the non-compliant hardware device
+      } else {
         d_class_id = d_oui << 32;
       }
       u_int64_t d_context_class_id = d_class_id ^ 1;

--- a/lib/difi_sink_cpp_impl.h
+++ b/lib/difi_sink_cpp_impl.h
@@ -53,6 +53,7 @@ namespace gr {
 
         int d_stream_number;
         u_int32_t d_full_samp;
+        static const long d_alt_oui = 0x7c386c;
         static const long d_oui = 0x6a621e;
         pmt::pmt_t d_context_key;
         pmt::pmt_t d_pkt_n_key;


### PR DESCRIPTION
Some specific values are required the DIFI Sink block to work with the Kratos Narrowband Digitizer. These values are used when 72-bit context packets are specified.