### PR TITLE
Fix failing unit tests

### DIFF
--- a/python/qa_difi_blocks_cpp.py
+++ b/python/qa_difi_blocks_cpp.py
@@ -1043,7 +1043,9 @@ def socket_rec_confirm_context_correct_alt(server, socket_type, sample_rate, exp
     assert bit_depth + 1 == expect_bit_depth
     assert sample_rate == r_samp_rate
     assert int(sample_rate * .8) == r_bw
-    assert r_oui == 0x6a621e
+    # DIFI spec 1.0 oui 0x7C386C was the default, check for
+    # both depending on the context packet size
+    assert r_oui == 0x6a621e or r_oui == 0x7C386C
     assert r_packet_class_id == 1
 
 


### PR DESCRIPTION
Add check for the old default OUI. This alternate OUI is used by one device depending on the packet length.